### PR TITLE
Update default image for db service. Previous image had some issues bootstrapping

### DIFF
--- a/docker/.env-dist
+++ b/docker/.env-dist
@@ -1,10 +1,10 @@
 # .env-dist
 # copy to .env and edit to fit your environment
 # or if you just hate defaults
- 
+
 # Docker image versions
-KCAPP_API_VERSION=v2.8.0
-KCAPP_FRONTEND_VERSION=v2.8.0
+KCAPP_API_VERSION=v2.9.0
+KCAPP_FRONTEND_VERSION=v2.9.0
 
 # Frontend settings
 KCAPP_FRONTEND_LISTEN_PORT=3000

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,11 +6,13 @@ services:
     image: nginx
     ports:
       - 80:80
+    depends_on:
+      - frontend
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
 
   db:
-    image: linuxserver/mariadb:${MYSQL_VERSION:-10.11.10}
+    image: linuxserver/mariadb:${MYSQL_VERSION:-11.4.5}
     hostname: db
     container_name: db
     restart: unless-stopped


### PR DESCRIPTION
Update default image for db service. Update default version in env-dist. Make nginx depend on frontend.